### PR TITLE
add scanvi and scanvi/scarches

### DIFF
--- a/docker/openproblems-python-scvi/requirements.txt
+++ b/docker/openproblems-python-scvi/requirements.txt
@@ -1,1 +1,1 @@
-scvi-tools
+scvi-tools[tutorials]>=0.9.1

--- a/openproblems/tasks/label_projection/api.py
+++ b/openproblems/tasks/label_projection/api.py
@@ -21,7 +21,7 @@ def check_method(adata):
 def sample_dataset():
     """Create a simple dataset to use for testing methods in this task."""
     adata = load_sample_data()
-    adata.obs["labels"] = np.random.choice(5, adata.shape[0], replace=True)
+    adata.obs["labels"] = np.random.choice(5, adata.shape[0], replace=True).astype(str)
     adata.obs["is_train"] = np.random.choice(
         [True, False], adata.shape[0], replace=True, p=[0.8, 0.2]
     )
@@ -33,5 +33,5 @@ def sample_method(adata):
     adata.obs["labels_pred"] = adata.obs["labels"]
     adata.obs["labels_pred"][::5] = np.random.choice(
         5, len(adata.obs["labels_pred"][::5]), replace=True
-    )
+    ).astype(str)
     return adata

--- a/openproblems/tasks/label_projection/api.py
+++ b/openproblems/tasks/label_projection/api.py
@@ -6,6 +6,7 @@ import numpy as np
 def check_dataset(adata):
     """Check that dataset output fits expected API."""
     assert "labels" in adata.obs
+    assert "batch" in adata.obs
     assert "is_train" in adata.obs
     assert np.sum(adata.obs["is_train"]) > 0
     assert np.sum(~adata.obs["is_train"]) > 0
@@ -21,6 +22,7 @@ def check_method(adata):
 def sample_dataset():
     """Create a simple dataset to use for testing methods in this task."""
     adata = load_sample_data()
+    adata.obs["batch"] = np.random.choice(5, adata.shape[0], replace=True).astype(str)
     adata.obs["labels"] = np.random.choice(5, adata.shape[0], replace=True).astype(str)
     adata.obs["is_train"] = np.random.choice(
         [True, False], adata.shape[0], replace=True, p=[0.8, 0.2]

--- a/openproblems/tasks/label_projection/datasets/pancreas.py
+++ b/openproblems/tasks/label_projection/datasets/pancreas.py
@@ -24,6 +24,7 @@ def pancreas_batch(test=False):
 def pancreas_random(test=False):
     adata = load_pancreas(test=test)
     adata.obs["labels"] = adata.obs["celltype"]
+    adata.obs["batch"] = adata.obs["tech"]
 
     # Assign training/test
     adata.obs["is_train"] = np.random.choice(

--- a/openproblems/tasks/label_projection/methods/__init__.py
+++ b/openproblems/tasks/label_projection/methods/__init__.py
@@ -4,3 +4,5 @@ from .logistic_regression import logistic_regression_log_cpm
 from .logistic_regression import logistic_regression_scran
 from .mlp import mlp_log_cpm
 from .mlp import mlp_scran
+from .scvi_tools import scanvi_all_genes
+from .scvi_tools import scanvi_hvg

--- a/openproblems/tasks/label_projection/methods/__init__.py
+++ b/openproblems/tasks/label_projection/methods/__init__.py
@@ -6,3 +6,5 @@ from .mlp import mlp_log_cpm
 from .mlp import mlp_scran
 from .scvi_tools import scanvi_all_genes
 from .scvi_tools import scanvi_hvg
+from .scvi_tools import scarches_scanvi_all_genes
+from .scvi_tools import scarches_scanvi_hvg

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -14,9 +14,10 @@ def _scanvi(adata):
     scvi_model.train(train_size=1.0)
     model = scvi.model.SCANVI.from_scvi_model(scvi_model, unlabeled_category="Unknown")
     model.train(train_size=1.0)
+    preds = model.predict(adata)
     del adata.obs["scanvi_labels"]
     # predictions for train and test
-    return model.predict(adata)
+    return preds
 
 
 def _scanvi_scarches(adata):
@@ -46,8 +47,12 @@ def _scanvi_scarches(adata):
     query_model = scvi.model.SCANVI.load_query_data(adata_test, model)
     query_model.train(max_epochs=200, plan_kwargs=dict(weight_decay=0.0))
 
+    # this is temporary and won't be used
+    adata.obs["scanvi_labels"] = "Unknown"
+    preds = query_model.predict(adata)
+    del adata.obs["scanvi_labels"]
     # predictions for train and test
-    return query_model.predict(adata)
+    return preds
 
 
 @method(

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -1,11 +1,10 @@
 from ....tools.decorators import method
 from ....tools.utils import check_version
 
-import scanpy as sc
-import scvi
-
 
 def _scanvi(adata):
+    import scvi
+
     scanvi_labels = adata.obs["labels"].to_numpy()
     # test set labels masked
     scanvi_labels[~adata.obs["is_train"].to_numpy()] = "Unknown"
@@ -46,6 +45,8 @@ def scanvi_all_genes(adata):
     image="openproblems-python-scvi",
 )
 def scanvi_hvg(adata):
+    import scanpy as sc
+
     bdata = adata.copy()
     bdata = sc.pp.highly_variable_genes(
         bdata, flavor="seurat_v3", subset=True, n_top_genes=2000

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -1,0 +1,47 @@
+from ....tools.decorators import method
+from ....tools.utils import check_version
+
+import scanpy as sc
+import scvi
+
+
+def _scanvi(adata):
+    adata_train = adata[adata.obs["is_train"]].copy()
+    scvi.data.setup_anndata(adata_train, batch_key="batch", labels_key="labels")
+    scvi_model = scvi.model.SCVI(adata_train, n_latent=30, n_layers=2, train_size=1.0)
+    scvi_model.train()
+    # all cells treated as labeled
+    model = scvi.model.SCANVI.from_scvi_model(scvi_model, unlabeled_category="Unknown")
+    model.train()
+    # predictions for train and test
+    return model.predict(adata)
+
+
+@method(
+    method_name="scANVI (All genes)",
+    paper_name="Probabilistic harmonization and annotation of single-cell"
+    " transcriptomics data with deep generative models.",
+    paper_url="https://www.embopress.org/doi/full/10.15252/msb.20209620",
+    paper_year=2021,
+    code_url="https://github.com/YosefLab/scvi-tools",
+    code_version=check_version("scvi"),
+)
+def scanvi_all_genes(adata):
+    adata.obs["labels_pred"] = _scanvi(adata)
+    return adata
+
+
+@method(
+    method_name="scANVI (Seurat v3 2000 HVG)",
+    paper_name="Probabilistic harmonization and annotation of single-cell"
+    " transcriptomics data with deep generative models.",
+    paper_url="https://www.embopress.org/doi/full/10.15252/msb.20209620",
+    paper_year=2021,
+    code_url="https://github.com/YosefLab/scvi-tools",
+    code_version=check_version("scvi"),
+)
+def scanvi_hvg(adata):
+    bdata = adata.copy()
+    bdata = sc.pp.highly_variable_genes(bdata, flavor="seurat_v3", subset=True)
+    adata.obs["labels_pred"] = _scanvi(bdata)
+    return adata

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -25,6 +25,7 @@ def _scanvi(adata):
     paper_year=2021,
     code_url="https://github.com/YosefLab/scvi-tools",
     code_version=check_version("scvi"),
+    image="openproblems-python-scvi",
 )
 def scanvi_all_genes(adata):
     adata.obs["labels_pred"] = _scanvi(adata)
@@ -39,6 +40,7 @@ def scanvi_all_genes(adata):
     paper_year=2021,
     code_url="https://github.com/YosefLab/scvi-tools",
     code_version=check_version("scvi"),
+    image="openproblems-python-scvi",
 )
 def scanvi_hvg(adata):
     bdata = adata.copy()

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -8,11 +8,11 @@ import scvi
 def _scanvi(adata):
     adata_train = adata[adata.obs["is_train"]].copy()
     scvi.data.setup_anndata(adata_train, batch_key="batch", labels_key="labels")
-    scvi_model = scvi.model.SCVI(adata_train, n_latent=30, n_layers=2, train_size=1.0)
-    scvi_model.train()
+    scvi_model = scvi.model.SCVI(adata_train, n_latent=30, n_layers=2)
+    scvi_model.train(train_size=1.0)
     # all cells treated as labeled
     model = scvi.model.SCANVI.from_scvi_model(scvi_model, unlabeled_category="Unknown")
-    model.train()
+    model.train(train_size=1.0)
     # predictions for train and test
     return model.predict(adata)
 

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -19,6 +19,37 @@ def _scanvi(adata):
     return model.predict(adata)
 
 
+def _scanvi_scarches(adata):
+    import scvi
+
+    # new obs labels to mask test set
+    adata_train = adata[adata.obs["is_train"]].copy()
+    adata_train.obs["scanvi_labels"] = adata_train.obs["labels"].copy()
+    adata_test = adata[~adata.obs["is_train"]].copy()
+    adata_test.obs["scanvi_labels"] = "Unknown"
+    scvi.data.setup_anndata(adata_train, batch_key="batch", labels_key="scanvi_labels")
+
+    # specific scArches parameters
+    arches_params = dict(
+        use_layer_norm="both",
+        use_batch_norm="none",
+        encode_covariates=True,
+        dropout_rate=0.2,
+        n_layers=2,
+        n_latent=30,
+    )
+    scvi_model = scvi.model.SCVI(adata, **arches_params)
+    scvi_model.train(train_size=1.0)
+    model = scvi.model.SCANVI.from_scvi_model(scvi_model, unlabeled_category="Unknown")
+    model.train(train_size=1.0)
+
+    query_model = scvi.model.SCANVI.load_query_data(adata_test, model)
+    query_model.train(max_epochs=200, plan_kwargs=dict(weight_decay=0.0))
+
+    # predictions for train and test
+    return query_model.predict(adata)
+
+
 @method(
     method_name="scANVI (All genes)",
     paper_name="Probabilistic harmonization and annotation of single-cell"
@@ -56,4 +87,42 @@ def scanvi_hvg(adata):
     )
     bdata = adata[:, hvg_df.highly_variable].copy()
     adata.obs["labels_pred"] = _scanvi(bdata)
+    return adata
+
+
+@method(
+    method_name="scArches+scANVI (All genes)",
+    paper_name="Query to reference single-cell integration with transfer learning.",
+    paper_url="https://www.biorxiv.org/content/10.1101/2020.07.16.205997v1",
+    paper_year=2021,
+    code_url="https://github.com/YosefLab/scvi-tools",
+    code_version=check_version("scvi"),
+    image="openproblems-python-scvi",
+)
+def scarches_scanvi_all_genes(adata):
+    adata.obs["labels_pred"] = _scanvi_scarches(adata)
+    return adata
+
+
+@method(
+    method_name="scArches+scANVI (Seurat v3 2000 HVG)",
+    paper_name="Query to reference single-cell integration with transfer learning.",
+    paper_url="https://www.biorxiv.org/content/10.1101/2020.07.16.205997v1",
+    paper_year=2021,
+    code_url="https://github.com/YosefLab/scvi-tools",
+    code_version=check_version("scvi"),
+    image="openproblems-python-scvi",
+)
+def scarches_scanvi_hvg(adata):
+    import scanpy as sc
+
+    hvg_df = sc.pp.highly_variable_genes(
+        adata[adata.obs["is_train"]],
+        flavor="seurat_v3",
+        inplace=False,
+        n_top_genes=2000,
+        batch_key="batch",
+    )
+    bdata = adata[:, hvg_df.highly_variable].copy()
+    adata.obs["labels_pred"] = _scanvi_scarches(bdata)
     return adata

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -42,6 +42,8 @@ def scanvi_all_genes(adata):
 )
 def scanvi_hvg(adata):
     bdata = adata.copy()
-    bdata = sc.pp.highly_variable_genes(bdata, flavor="seurat_v3", subset=True)
+    bdata = sc.pp.highly_variable_genes(
+        bdata, flavor="seurat_v3", subset=True, n_top_genes=2000
+    )
     adata.obs["labels_pred"] = _scanvi(bdata)
     return adata

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -47,9 +47,13 @@ def scanvi_all_genes(adata):
 def scanvi_hvg(adata):
     import scanpy as sc
 
-    bdata = adata.copy()
-    bdata = sc.pp.highly_variable_genes(
-        bdata, flavor="seurat_v3", subset=True, n_top_genes=2000
+    hvg_df = sc.pp.highly_variable_genes(
+        adata[adata.obs["is_train"]],
+        flavor="seurat_v3",
+        inplace=False,
+        n_top_genes=2000,
+        batch_key="batch",
     )
+    bdata = adata[:, hvg_df.highly_variable].copy()
     adata.obs["labels_pred"] = _scanvi(bdata)
     return adata

--- a/openproblems/tasks/label_projection/methods/scvi_tools.py
+++ b/openproblems/tasks/label_projection/methods/scvi_tools.py
@@ -38,7 +38,7 @@ def _scanvi_scarches(adata):
         n_layers=2,
         n_latent=30,
     )
-    scvi_model = scvi.model.SCVI(adata, **arches_params)
+    scvi_model = scvi.model.SCVI(adata_train, **arches_params)
     scvi_model.train(train_size=1.0)
     model = scvi.model.SCANVI.from_scvi_model(scvi_model, unlabeled_category="Unknown")
     model.train(train_size=1.0)


### PR DESCRIPTION
Adds:

1.  scANVI as a method in both all genes form, and with HVG preprocessing.
2. scArches variants of (1)
3. Fixes to `api.py` to use string labels and enforce batch information being in anndata.

Some helpful code to try this locally:

```
openproblems-cli list --datasets --task label_projection
openproblems-cli load --task label_projection --output pancreas_batch.h5ad pancreas_batch 
openproblems-cli run --task label_projection --input pancreas_batch.h5ad --output method.h5ad scanvi_hvg
openproblems-cli evaluate --task label_projection --input method.h5ad accuracy 
```
Though `pancreas_batch` has non-integer data I think because of it's not all UMI based, so `scanvi_hvg` fails.