### PR TITLE
Add label noise

### DIFF
--- a/openproblems/tasks/label_projection/datasets/__init__.py
+++ b/openproblems/tasks/label_projection/datasets/__init__.py
@@ -1,4 +1,5 @@
 from .pancreas import pancreas_batch
 from .pancreas import pancreas_random
+from .pancreas import pancreas_random_label_noise
 from .zebrafish import zebrafish_labels
 from .zebrafish import zebrafish_random

--- a/openproblems/tasks/label_projection/datasets/pancreas.py
+++ b/openproblems/tasks/label_projection/datasets/pancreas.py
@@ -1,5 +1,6 @@
 from ....data.pancreas import load_pancreas
 from ....tools.decorators import dataset
+from .tools import add_label_noise
 
 import numpy as np
 
@@ -29,5 +30,21 @@ def pancreas_random(test=False):
     adata.obs["is_train"] = np.random.choice(
         [True, False], adata.shape[0], replace=True, p=[0.8, 0.2]
     )
+
+    return adata
+
+
+@dataset(r"Pancreas (random split with 20% label noise")
+def pancreas_random_label_noise(test=False):
+    adata = load_pancreas(test=test)
+    adata.obs["labels"] = adata.obs["celltype"]
+
+    # Assign trainin/test
+    adata.obs["is_train"] = np.random.choice(
+        [True, False], adata.shape[0], replace=True, p=[0.8, 0.2]
+    )
+
+    # Inject label noise
+    adata = add_label_noise(adata, noise_prob=0.2)
 
     return adata

--- a/openproblems/tasks/label_projection/datasets/tools/__init__.py
+++ b/openproblems/tasks/label_projection/datasets/tools/__init__.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pandas as pd
+
+
+def add_label_noise(adata, noise_prob):
+    """Inject random label noise in the dataset by permuting a fraction
+    of the labels in the training set.
+
+    By adding different levels of label noise metrics can be evaluated to show
+    generalization trends from training data even if ground truth is uncertain.
+
+    Params
+    -------
+    adata: AnnData, a dataset with the required fields for the label_projection task.
+
+    noise_prob: Float, the probability of label noise in the training data.
+
+    Returns
+    -------
+    AnnData: dataset where training labels have been permuted by specified probability.
+    """
+
+    old_labels = adata.obs["labels"].pipe(np.array)
+    new_labels = adata.obs["labels"].pipe(np.array)
+
+    label_names = np.unique(new_labels)
+
+    n_labels = label_names.shape[0]
+
+    reassign_probs = (noise_prob / (n_labels - 1)) * np.ones((n_labels, n_labels))
+
+    np.fill_diagonal(reassign_probs, 1 - noise_prob)
+
+    for k, label in enumerate(label_names):
+        label_indices = np.where(old_labels == label)[0]
+        new_labels[label_indices] = np.random.choice(
+            label_names, label_indices.shape[0], p=reassign_probs[:, k]
+        )

--- a/openproblems/tasks/label_projection/datasets/tools/__init__.py
+++ b/openproblems/tasks/label_projection/datasets/tools/__init__.py
@@ -36,3 +36,8 @@ def add_label_noise(adata, noise_prob):
         new_labels[label_indices] = np.random.choice(
             label_names, label_indices.shape[0], p=reassign_probs[:, k]
         )
+
+    new_adata = adata.copy()
+    new_adata.obs["labels"] = new_labels
+
+    return new_adata

--- a/openproblems/tasks/label_projection/datasets/tools/__init__.py
+++ b/openproblems/tasks/label_projection/datasets/tools/__init__.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 
 
 def add_label_noise(adata, noise_prob):

--- a/openproblems/tasks/label_projection/datasets/tools/__init__.py
+++ b/openproblems/tasks/label_projection/datasets/tools/__init__.py
@@ -41,7 +41,6 @@ def add_label_noise(adata, noise_prob):
             label_names, label_indices.shape[0], p=reassign_probs[:, k]
         )
 
-    new_adata = adata.copy()
-    new_adata.obs.loc[adata.obs["is_train"], "labels"] = new_labels_train
+    adata.obs.loc[adata.obs["is_train"], "labels"] = new_labels_train
 
-    return new_adata
+    return adata

--- a/openproblems/tasks/label_projection/datasets/tools/__init__.py
+++ b/openproblems/tasks/label_projection/datasets/tools/__init__.py
@@ -21,9 +21,10 @@ def add_label_noise(adata, noise_prob):
     """
 
     old_labels = adata.obs["labels"].pipe(np.array)
-    new_labels = adata.obs["labels"].pipe(np.array)
+    old_labels_train = old_labels[adata.obs["is_train"]].copy()
+    new_labels_train = old_labels_train.copy()
 
-    label_names = np.unique(new_labels)
+    label_names = np.unique(new_labels_train)
 
     n_labels = label_names.shape[0]
 
@@ -32,12 +33,12 @@ def add_label_noise(adata, noise_prob):
     np.fill_diagonal(reassign_probs, 1 - noise_prob)
 
     for k, label in enumerate(label_names):
-        label_indices = np.where(old_labels == label)[0]
-        new_labels[label_indices] = np.random.choice(
+        label_indices = np.where(old_labels_train == label)[0]
+        new_labels_train[label_indices] = np.random.choice(
             label_names, label_indices.shape[0], p=reassign_probs[:, k]
         )
 
     new_adata = adata.copy()
-    new_adata.obs["labels"] = new_labels
+    new_adata.obs.loc[adata.obs["is_train"], "labels"] = new_labels_train
 
     return new_adata

--- a/openproblems/tasks/label_projection/datasets/tools/__init__.py
+++ b/openproblems/tasks/label_projection/datasets/tools/__init__.py
@@ -2,21 +2,25 @@ import numpy as np
 
 
 def add_label_noise(adata, noise_prob):
-    """Inject random label noise in the dataset by permuting a fraction
-    of the labels in the training set.
+    """Inject random label noise in the dataset .
+
+    This is done by permuting a fraction of the labels in the training set.
 
     By adding different levels of label noise metrics can be evaluated to show
     generalization trends from training data even if ground truth is uncertain.
 
-    Params
+    Parameters
     -------
-    adata: AnnData, a dataset with the required fields for the label_projection task.
+    adata : AnnData
+        A dataset with the required fields for the label_projection task.
 
-    noise_prob: Float, the probability of label noise in the training data.
+    noise_prob : Float
+        The probability of label noise in the training data.
 
     Returns
     -------
-    AnnData: dataset where training labels have been permuted by specified probability.
+    new_adata : AnnData
+        Dataset where training labels have been permuted by specified probability.
     """
 
     old_labels = adata.obs["labels"].pipe(np.array)


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This pull request adds a tool for `label_projection` datasets that introduces label noise.

We evaluate a metric such as Accuracy on test data, but we are unsure how "true" our training labels are. By evaluating the test Accuracy when we have artificially introduce label error at different levels we can look at the metric for several levels of artificial label noise. This resulting curves show how good the method will be at generalizing in the presence of mislabeled data. If curves for multiple methods are plotted on the same graph, a method whose curve have systematically better scores is the better performer.

The introduced tool method `add_label_noise` randomly relabels a fraction of the labels specified by the `noise_prob` parameter. Only labels from the training set are randomized.

### Submission type

* [x] This submission adds a new dataset
* [ ] This submission adds a new method
* [ ] This submission adds a new metric
* [ ] This submission adds a new task
* [ ] This submission adds a new Docker image
* [ ] This submission fixes a bug (link to related issue: )
* [ ] This submission adds a new feature not listed above

### Testing

* [x] This submission was written on a forked copy of SingleCellOpenProblems
* [ ] GitHub Actions "Run Benchmark" tests are passing on this base branch of this pull request (include link to passed test: )
* [ ] If this pull request is not ready for review (including passing the "Run Benchmark" tests), I will open this PR as a draft (click on the down arrow next to the "Create Pull Request" button)

### Submission guidelines

* [x] This submission follows the guidelines in our [Contributing](../blob/master/CONTRIBUTING.md) document
* [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change
